### PR TITLE
fixed: 终点不可达时，start heuristic不为0时 endless loop

### DIFF
--- a/pathfinding.c
+++ b/pathfinding.c
@@ -234,6 +234,8 @@ astar(struct context *ctx, uint start, uint goal) {
 		current = &ctx->hash[list];
 		if (current->coord == goal)
 			return list;
+		else if (size != 1 && current->next < 0)
+			return -1; // the last open node, can't find goal
 		struct pathfinding_neighbor neighbor[NEIGHBOR_MAX];
 		int n = ctx->func(ctx->ud, current->coord, neighbor);
 		if (n == 0) {


### PR DESCRIPTION
```log
Layout Dump (center: 10,10, radius: 10):
 20                                         #  #  #  #
 19                                         #  #  #  #
 18
 17
 16
 15
 14                                               #  #  #  #  #
 13                                   #  #  #     #  #  #  #  #
 12                                   #  #  #     #  #  #  #  #
 11                                   #  #  #     #  #  #  #  #
 10                                               #  #  #  #  #
  9
  8
  7
  6
  5
  4
  3
  2
  1
  0
     0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20
```
find_path(0,0,12,12)
当终点在阻挡中时，起点heuristic 不为0时时死循环